### PR TITLE
Updating moodle appliance to v17.

### DIFF
--- a/changelog
+++ b/changelog
@@ -1,6 +1,11 @@
 turnkey-moodle-17.0 (1) turnkey; urgency=low
 
+  * Update Moodle appliance and its dependencies to tkldev v17.0.
+
+  * Remove execute flag for sql command that was causing build error in conf.d/main file. 
+
   * Update Moodle to latest upstream release (4.0.0).
+    [ Zhenya Hvorostian <zhenya@turnkeylinux.org>]
 
   * Various security tweaks.
     [ Jeremy Davis <jeremy@turnkeykinux.org> ]
@@ -8,7 +13,7 @@ turnkey-moodle-17.0 (1) turnkey; urgency=low
   * Run Moodle cron job every minute - closes #1453.
     [ Stefan Davis <stefan@turnkeykinux.org> ]
 
- -- Zhenya Hvorostian <zhenya@turnkeylinux.org> Tue, 26 Apr 2022 15:27:07 +0000
+ -- Mattie Darden <mattie@turnkeylinux.org>  Thu, 22 Sep 2022 10:34:24 -0400
 
 turnkey-moodle-16.1 (1) turnkey; urgency=low
 

--- a/changelog
+++ b/changelog
@@ -12,6 +12,9 @@ turnkey-moodle-17.0 (1) turnkey; urgency=low
 
   * Run Moodle cron job every minute - closes #1453.
     [ Stefan Davis <stefan@turnkeykinux.org> ]
+    
+  * Note: Please refer to turnkey-core's 16.1 changelog for changes common to all
+    appliances. Here we only describe changes specific to this appliance.
 
  -- Mattie Darden <mattie@turnkeylinux.org>  Thu, 22 Sep 2022 10:34:24 -0400
 

--- a/conf.d/main
+++ b/conf.d/main
@@ -97,7 +97,7 @@ EOF
 
 # disable user delete - removes hyped up "critical" warning
 # - see https://tracker.moodle.org/browse/MDL-67852 for more info
-mysql -e <<EOF
+mysql <<EOF
 USE $DB_NAME;
 DELETE FROM role_capabilities WHERE capability = "tool/dataprivacy:requestdelete";
 EOF


### PR DESCRIPTION
PR updates moodle appliance and dependencies to tkldev v17.0. Updates includes removing unnecessary execute flag for sql command in conf.d/main file. All update changes have been documented in appliance changelog.