### PR TITLE
Release candidate: turnkey-moodle5-18.1-bookworm-amd64_2025-10-29_08-05UTC

### DIFF
--- a/changelog
+++ b/changelog
@@ -1,3 +1,11 @@
+turnkey-moodle5-18.1 (1) turnkey; urgency=low
+
+  * Install latest upstream version of Moodle 5.x: 5.1.0+ (as of today,
+    download via git branch MOODLE_501_STABLE).
+
+  * Set correct permissions and creating (eventually) missing folders.
+
+
 turnkey-moodle-18.0 (1) turnkey; urgency=low
 
   * Install latest upstream version of Moodle: 4.3.0+ (as of today,

--- a/changelog
+++ b/changelog
@@ -5,6 +5,7 @@ turnkey-moodle5-18.1 (1) turnkey; urgency=low
 
   * Set correct permissions and creating (eventually) missing folders.
 
+  * Change pointing to /public.
 
 turnkey-moodle-18.0 (1) turnkey; urgency=low
 

--- a/changelog
+++ b/changelog
@@ -1,8 +1,3 @@
-turnkey-moodle5-18.1 (1) turnkey; urgency=low
-
-  * Install latest upstream version of Moodle: 5.1+ (as of today,
-    download via git branch MOODLE_501_STABLE).
-
 turnkey-moodle-18.0 (1) turnkey; urgency=low
 
   * Install latest upstream version of Moodle: 4.3.0+ (as of today,

--- a/changelog
+++ b/changelog
@@ -1,3 +1,8 @@
+turnkey-moodle5-18.1 (1) turnkey; urgency=low
+
+  * Install latest upstream version of Moodle: 5.1+ (as of today,
+    download via git branch MOODLE_501_STABLE).
+
 turnkey-moodle-18.0 (1) turnkey; urgency=low
 
   * Install latest upstream version of Moodle: 4.3.0+ (as of today,

--- a/conf.d/main
+++ b/conf.d/main
@@ -75,6 +75,7 @@ php admin/cli/install.php \
     --agree-license
 
 chown -R www-data:www-data $DATAROOT
+chown -R www-data:www-data /var/www/moodle/theme
 chown root:www-data $WEBROOT/config.php
 
 ## tweak config

--- a/conf.d/main
+++ b/conf.d/main
@@ -1,8 +1,20 @@
 #!/bin/bash -ex
 
+# REFERENCE: https://docs.moodle.org/501/en/Git_for_Administrators
+
+MOODLE_BRANCH="MOODLE_501_STABLE"
+
+# Determine Moodle version from branch
+if [[ "$MOODLE_BRANCH" == *"MOODLE_4"* ]]; then
+    DEFAULT_MOODLE_VERSION="4"
+elif [[ "$MOODLE_BRANCH" == *"MOODLE_5"* ]]; then
+    DEFAULT_MOODLE_VERSION="5"
+else
+    DEFAULT_MOODLE_VERSION="4"
+fi
+
 WEBROOT=/var/www/moodle
 DATAROOT=/var/www/moodledata
-MOOSHROOT=/var/www/moosh
 
 DB_NAME=moodle
 DB_USER=moodle
@@ -34,26 +46,13 @@ a2enmod headers
 sed -Ei "/max_input_vars/ s|^;?(max_input_vars =).*|\1 5000|" /etc/php/8.2/apache2/php.ini
 sed -Ei "/max_input_vars/ s|^;?(max_input_vars =).*|\1 5000|" /etc/php/8.2/cli/php.ini
 
-cd $(dirname $MOOSHROOT)
-git clone https://github.com/tmuras/moosh.git
-cd $MOOSHROOT
-chown -R www-data:www-data $MOOSHROOT
-if [[ -n "$GITHUB_USER_TOKEN" ]]; then
-    turnkey-composer config github-oauth.github.com $GITHUB_USER_TOKEN
-else
-    echo "WARNING: GITHUB_USER_TOKEN not set, build may fail" >&2
-fi
-turnkey-composer install
-ln -s $MOOSHROOT/moosh.php /usr/local/bin/moosh
-
-# download latest moodle with moosh, then unpack
-cd $(dirname $WEBROOT)
-moosh download-moodle
-tar -C $(dirname $WEBROOT) -zxf moodle-*.tgz
-rm -f moodle-*.tgz
+# download latest moodle with git
+git clone git://git.moodle.org/moodle.git $WEBROOT
+cd $WEBROOT
+git branch --track $MOODLE_BRANCH origin/$MOODLE_BRANCH
+git checkout $MOODLE_BRANCH
 chown -R root:root $WEBROOT
 
-cd $WEBROOT
 php admin/cli/install.php \
     --chmod=750 \
     --lang=en \
@@ -110,3 +109,573 @@ EOF
 
 # stop mysql server
 systemctl stop  mysql
+
+#!/bin/bash
+# ========================================================
+# Moodle Permissions Manager - Unified Script
+# Supports Moodle 4.x and 5.x
+# ========================================================
+
+# Ubuntu-style release variable (SCRIPT RELEASE)
+SCRIPT_RELEASE="25.10"
+SCRIPT_CODENAME="Universal Hawk"
+SCRIPT_DATE="2025-10-25"
+SCRIPT_AUTHOR="Daniele Lolli (UncleDan)"
+SCRIPT_LICENSE="GPL-3.0"
+
+# Default Moodle version (independent from script release)
+DEFAULT_MOODLE_VERSION="4"
+
+set -e  # Exit immediately on error
+
+# Default configurations
+MOODLE_DIR=${WEBROOT}
+MOODLEDATA_DIR=${DATAROOT}
+WWW_USER="www-data"
+WWW_GROUP="www-data"
+
+# Determine Moodle version (use default if not specified)
+MOODLE_VERSION="$DEFAULT_MOODLE_VERSION"
+
+# Function to show header
+show_header() {
+    echo "================================================================================"
+    echo "Moodle Permissions Manager v${SCRIPT_RELEASE} (${SCRIPT_CODENAME})"
+    echo "================================================================================"
+    echo "Author: ${SCRIPT_AUTHOR}"
+    echo "Release: ${SCRIPT_RELEASE} - ${SCRIPT_DATE}"
+    echo "License: ${SCRIPT_LICENSE}"
+    echo "Default Moodle Version: ${DEFAULT_MOODLE_VERSION}.x"
+    echo "Selected Moodle Version: ${MOODLE_VERSION}.x"
+    echo "================================================================================"
+    echo ""
+}
+
+# Function to show help
+show_help() {
+    echo "Usage: $0 [OPTIONS]"
+    echo ""
+    echo "Options:"
+    echo "  -h, --help              Show this help message"
+    echo "  -v, --version           Show version information"
+    echo "  -d, --dry-run           Simulate operations without applying changes"
+    echo "  -s, --show-perms        Show current permissions without modifying"
+    echo "  -mp, --moodlepath PATH  Specify Moodle installation path"
+    echo "  -md, --moodledata PATH  Specify moodledata path"
+    echo "  -mv, --moodleversion VERSION Specify Moodle version (4|5)"
+    echo ""
+    echo "Examples:"
+    echo "  $0                               # Use default version (Moodle ${DEFAULT_MOODLE_VERSION})"
+    echo "  $0 -mv 5                         # Force Moodle version 5"
+    echo "  $0 -mv 4 -d                      # Moodle 4 in dry-run mode"
+    echo "  $0 -mv 5 -s                      # Show current permissions for Moodle 5"
+    echo "  $0 -mp /opt/moodle -mv 5         # Custom path + version"
+    echo "  $0 -mp /opt/moodle -md /opt/moodledata -mv 4 -s  # All parameters + show"
+    echo ""
+    echo "Notes:"
+    echo "  Default Moodle version: ${DEFAULT_MOODLE_VERSION}.x"
+    echo "  Script version: ${SCRIPT_RELEASE}"
+}
+
+# Function to show version
+show_version() {
+    echo "Moodle Permissions Manager v${SCRIPT_RELEASE}"
+    echo "Codename: ${SCRIPT_CODENAME}"
+    echo "Release Date: ${SCRIPT_DATE}"
+    echo "Author: ${SCRIPT_AUTHOR}"
+    echo "License: ${SCRIPT_LICENSE}"
+    echo "Default Moodle Version: ${DEFAULT_MOODLE_VERSION}.x"
+    echo "Compatible with: Moodle 4.x & 5.x, Debian 11/12, Ubuntu 20.04+"
+    exit 0
+}
+
+# Function to validate Moodle version
+validate_moodle_version() {
+    local version=$1
+    if [[ "$version" != "4" && "$version" != "5" ]]; then
+        echo "❌ ERROR: Invalid Moodle version: '$version'"
+        echo "   Use '4' for Moodle 4.x or '5' for Moodle 5.x"
+        exit 1
+    fi
+}
+
+# Function to check main directories existence
+check_main_directories() {
+    if [ ! -d "$MOODLE_DIR" ]; then
+        echo "❌ ERROR: Moodle directory not found: $MOODLE_DIR"
+        exit 1
+    fi
+    
+    if [ ! -d "$MOODLEDATA_DIR" ]; then
+        echo "❌ ERROR: Moodledata directory not found: $MOODLEDATA_DIR"
+        exit 1
+    fi
+}
+
+# Function to show current permissions for Moodle 4
+show_moodle4_permissions() {
+    echo "🔍 Current Moodle 4 directory permissions:"
+    echo ""
+    
+    echo "📁 Main directories:"
+    for dir in "$MOODLE_DIR" "$MOODLEDATA_DIR"; do
+        if [ -d "$dir" ]; then
+            perms=$(stat -c "%a %U:%G" "$dir")
+            echo "   $dir: $perms"
+        else
+            echo "   $dir: ❌ NOT FOUND"
+        fi
+    done
+    
+    echo ""
+    echo "📁 Specific Moodle 4 directories:"
+    local moodle4_dirs=("cache" "temp" "sessions" "lang" "h5p" "backup" "restore" "trashdir" "webservice" "filedir" "repository" "log")
+    
+    for dir in "${moodle4_dirs[@]}"; do
+        local full_path="$MOODLEDATA_DIR/$dir"
+        if [ -d "$full_path" ]; then
+            perms=$(stat -c "%a %U:%G" "$full_path")
+            echo "   $full_path: $perms"
+        else
+            echo "   $full_path: 📁 DOES NOT EXIST"
+        fi
+    done
+    
+    echo ""
+    echo "📁 config.php file:"
+    if [ -f "$MOODLE_DIR/config.php" ]; then
+        perms=$(stat -c "%a %U:%G" "$MOODLE_DIR/config.php")
+        echo "   $MOODLE_DIR/config.php: $perms"
+    else
+        echo "   $MOODLE_DIR/config.php: ❌ NOT FOUND"
+    fi
+    
+    echo ""
+    echo "📁 CLI scripts:"
+    if [ -d "$MOODLE_DIR/admin/cli" ]; then
+        local cli_scripts=$(find "$MOODLE_DIR/admin/cli" -name "*.php" | head -3)
+        if [ -n "$cli_scripts" ]; then
+            echo "   First 3 CLI scripts:"
+            while IFS= read -r script; do
+                if [ -f "$script" ]; then
+                    perms=$(stat -c "%a %U:%G" "$script")
+                    echo "   $script: $perms"
+                fi
+            done <<< "$cli_scripts"
+        else
+            echo "   No CLI scripts found"
+        fi
+    else
+        echo "   CLI directory not found"
+    fi
+}
+
+# Function to show current permissions for Moodle 5
+show_moodle5_permissions() {
+    echo "🔍 Current Moodle 5 directory permissions:"
+    echo ""
+    
+    echo "📁 Main directories:"
+    for dir in "$MOODLE_DIR" "$MOODLEDATA_DIR"; do
+        if [ -d "$dir" ]; then
+            perms=$(stat -c "%a %U:%G" "$dir")
+            echo "   $dir: $perms"
+        else
+            echo "   $dir: ❌ NOT FOUND"
+        fi
+    done
+    
+    echo ""
+    echo "📁 Specific Moodle 5 directories:"
+    local moodle5_dirs=("cache" "temp" "lock" "tasks" "localcache" "sessions" "lang" "h5p" "backup" "restore" "trash" "webservice")
+    
+    for dir in "${moodle5_dirs[@]}"; do
+        local full_path="$MOODLEDATA_DIR/$dir"
+        if [ -d "$full_path" ]; then
+            perms=$(stat -c "%a %U:%G" "$full_path")
+            echo "   $full_path: $perms"
+        else
+            echo "   $full_path: 📁 DOES NOT EXIST"
+        fi
+    done
+    
+    echo ""
+    echo "📁 config.php file:"
+    if [ -f "$MOODLE_DIR/config.php" ]; then
+        perms=$(stat -c "%a %U:%G" "$MOODLE_DIR/config.php")
+        echo "   $MOODLE_DIR/config.php: $perms"
+    else
+        echo "   $MOODLE_DIR/config.php: ❌ NOT FOUND"
+    fi
+    
+    echo ""
+    echo "📁 CLI scripts:"
+    if [ -d "$MOODLE_DIR/admin/cli" ]; then
+        local cli_scripts=$(find "$MOODLE_DIR/admin/cli" -name "*.php" | head -3)
+        if [ -n "$cli_scripts" ]; then
+            echo "   First 3 CLI scripts:"
+            while IFS= read -r script; do
+                if [ -f "$script" ]; then
+                    perms=$(stat -c "%a %U:%G" "$script")
+                    echo "   $script: $perms"
+                fi
+            done <<< "$cli_scripts"
+        else
+            echo "   No CLI scripts found"
+        fi
+    else
+        echo "   CLI directory not found"
+    fi
+}
+
+# Function to show current permissions
+show_current_permissions() {
+    echo "🔍 [SHOW-PERMS] Displaying current permissions - No changes will be applied"
+    echo "🎯 Moodle Version: ${MOODLE_VERSION}.x"
+    echo ""
+    
+    if [ "$MOODLE_VERSION" = "4" ]; then
+        show_moodle4_permissions
+    else
+        show_moodle5_permissions
+    fi
+    
+    echo ""
+    echo "📋 Recommended permissions:"
+    echo "   - Moodle directory: 755 (dir) / 644 (file)"
+    echo "   - Moodledata directory: 770 (dir) / 660 (file)"
+    echo "   - config.php: 640"
+    echo "   - CLI scripts: 755"
+    echo "   - Owner: ${WWW_USER}:${WWW_GROUP}"
+    
+    exit 0
+}
+
+# Function to create directory if missing
+create_directory_if_missing() {
+    local dir="$1"
+    if [ ! -d "$dir" ]; then
+        echo "📁 Creating directory: $dir"
+        mkdir -p "$dir"
+        return 0  # Directory created
+    else
+        return 1  # Directory already exists
+    fi
+}
+
+# Function to create critical Moodle 4 directories
+create_moodle4_directories() {
+    echo "📁 Creating critical Moodle 4 directories..."
+    
+    local moodle4_dirs=("cache" "temp" "sessions" "lang" "h5p" "backup" "restore" "trashdir" "webservice" "filedir" "repository" "log")
+    
+    for dir in "${moodle4_dirs[@]}"; do
+        local full_path="$MOODLEDATA_DIR/$dir"
+        if create_directory_if_missing "$full_path"; then
+            echo "   ✅ Created: $dir"
+        else
+            echo "   📁 Existing: $dir"
+        fi
+    done
+}
+
+# Function to create critical Moodle 5 directories
+create_moodle5_directories() {
+    echo "📁 Creating critical Moodle 5 directories..."
+    
+    local moodle5_dirs=("cache" "temp" "lock" "tasks" "localcache" "sessions" "lang" "h5p" "backup" "restore" "trash" "webservice")
+    
+    for dir in "${moodle5_dirs[@]}"; do
+        local full_path="$MOODLEDATA_DIR/$dir"
+        if create_directory_if_missing "$full_path"; then
+            echo "   ✅ Created: $dir"
+        else
+            echo "   📁 Existing: $dir"
+        fi
+    done
+}
+
+# Function to set Moodle 4 permissions
+set_moodle4_permissions() {
+    echo "🎯 Setting specific Moodle 4 permissions..."
+    
+    local moodle4_dirs=("cache" "temp" "sessions" "lang" "h5p" "backup" "restore" "trashdir" "webservice" "filedir" "repository" "log")
+    
+    for dir in "${moodle4_dirs[@]}"; do
+        if [ -d "$MOODLEDATA_DIR/$dir" ]; then
+            chmod 770 "$MOODLEDATA_DIR/$dir"
+            echo "   ✅ $dir directory set to 770"
+        fi
+    done
+}
+
+# Function to set Moodle 5 permissions
+set_moodle5_permissions() {
+    echo "🎯 Setting specific Moodle 5 permissions..."
+    
+    local moodle5_dirs=("cache" "temp" "lock" "tasks" "localcache" "sessions" "lang" "h5p" "backup" "restore" "trash" "webservice")
+    
+    for dir in "${moodle5_dirs[@]}"; do
+        if [ -d "$MOODLEDATA_DIR/$dir" ]; then
+            chmod 770 "$MOODLEDATA_DIR/$dir"
+            echo "   ✅ $dir directory set to 770"
+        fi
+    done
+}
+
+# Function for Moodle 4 dry-run
+dry_run_moodle4() {
+    echo "📋 Specific Moodle 4 operations that would be executed:"
+    
+    local moodle4_dirs=("cache" "temp" "sessions" "lang" "h5p" "backup" "restore" "trashdir" "webservice" "filedir" "repository" "log")
+    
+    for dir in "${moodle4_dirs[@]}"; do
+        if [ -d "$MOODLEDATA_DIR/$dir" ]; then
+            echo "   chmod 770 \"$MOODLEDATA_DIR/$dir\""
+        else
+            echo "   mkdir -p \"$MOODLEDATA_DIR/$dir\" && chmod 770 \"$MOODLEDATA_DIR/$dir\""
+        fi
+    done
+    
+    echo ""
+    echo "📝 Moodle 4 specific notes:"
+    echo "   - 'trashdir' directory instead of 'trash'"
+    echo "   - 'filedir' for main file storage"
+    echo "   - 'repository' for repository files"
+    echo "   - 'log' dedicated directory for logs"
+}
+
+# Function for Moodle 5 dry-run
+dry_run_moodle5() {
+    echo "📋 Specific Moodle 5 operations that would be executed:"
+    
+    local moodle5_dirs=("cache" "temp" "lock" "tasks" "localcache" "sessions" "lang" "h5p" "backup" "restore" "trash" "webservice")
+    
+    for dir in "${moodle5_dirs[@]}"; do
+        if [ -d "$MOODLEDATA_DIR/$dir" ]; then
+            echo "   chmod 770 \"$MOODLEDATA_DIR/$dir\""
+        else
+            echo "   mkdir -p \"$MOODLEDATA_DIR/$dir\" && chmod 770 \"$MOODLEDATA_DIR/$dir\""
+        fi
+    done
+    
+    echo ""
+    echo "📝 Moodle 5 specific notes:"
+    echo "   - 'lock' directory for improved lock management"
+    echo "   - 'tasks' directory for task scheduling"
+    echo "   - 'localcache' directory for local cache"
+    echo "   - 'trash' directory instead of 'trashdir'"
+}
+
+# Function for dry-run
+dry_run() {
+    echo "🔍 [DRY-RUN] Simulation mode active - No changes will be applied"
+    echo "🎯 Moodle Version: ${MOODLE_VERSION}.x"
+    echo ""
+    
+    echo "📋 Common operations that would be executed:"
+    echo "   chown -R ${WWW_USER}:${WWW_GROUP} \"$MOODLE_DIR\""
+    echo "   chown -R ${WWW_USER}:${WWW_GROUP} \"$MOODLEDATA_DIR\""
+    echo "   find \"$MOODLE_DIR\" -type d -exec chmod 755 {} \\;"
+    echo "   find \"$MOODLE_DIR\" -type f -exec chmod 644 {} \\;"
+    echo "   find \"$MOODLEDATA_DIR\" -type d -exec chmod 770 {} \\;"
+    echo "   find \"$MOODLEDATA_DIR\" -type f -exec chmod 660 {} \\;"
+    
+    if [ -f "$MOODLE_DIR/config.php" ]; then
+        echo "   chmod 640 \"$MOODLE_DIR/config.php\""
+    else
+        echo "   # config.php not found in $MOODLE_DIR (will be skipped)"
+    fi
+    
+    if [ -d "$MOODLE_DIR/admin/cli" ]; then
+        echo "   find \"$MOODLE_DIR/admin/cli\" -name \"*.php\" -exec chmod 755 {} \\;"
+    else
+        echo "   # CLI directory not found in $MOODLE_DIR/admin/cli (will be skipped)"
+    fi
+    
+    echo ""
+    
+    # Version-specific operations
+    if [ "$MOODLE_VERSION" = "4" ]; then
+        dry_run_moodle4
+    else
+        dry_run_moodle5
+    fi
+    
+    echo ""
+    echo "🔍 Verifications that would be executed:"
+    echo "   stat -c \"%a %U:%G\" \"$MOODLEDATA_DIR\""
+    echo "   stat -c \"%a %U:%G\" \"$MOODLE_DIR\""
+    
+    echo ""
+    echo "✅ [DRY-RUN] Simulation completed - No changes applied"
+    exit 0
+}
+
+# Argument parsing
+DRY_RUN=false
+SHOW_PERMS=false
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        -h|--help)
+            show_header
+            show_help
+            exit 0
+            ;;
+        -v|--version)
+            show_version
+            ;;
+        -d|--dry-run)
+            DRY_RUN=true
+            shift
+            ;;
+        -s|--show-perms)
+            SHOW_PERMS=true
+            shift
+            ;;
+        -mp|--moodlepath)
+            MOODLE_DIR="$2"
+            shift 2
+            ;;
+        -md|--moodledata)
+            MOODLEDATA_DIR="$2"
+            shift 2
+            ;;
+        -mv|--moodleversion)
+            MOODLE_VERSION="$2"
+            validate_moodle_version "$MOODLE_VERSION"
+            shift 2
+            ;;
+        *)
+            echo "❌ Unknown argument: $1"
+            echo "Use $0 --help to see available options"
+            exit 1
+            ;;
+    esac
+done
+
+# Show header
+show_header
+
+echo "🎯 Detected configuration:"
+echo "   - Moodle Version: ${MOODLE_VERSION}.x"
+echo "   - Moodle Directory: $MOODLE_DIR"
+echo "   - Moodledata Directory: $MOODLEDATA_DIR"
+echo ""
+
+# Verify script is run as root (except for show-perms)
+if [ "$SHOW_PERMS" = false ] && [ "$(id -u)" -ne 0 ]; then
+    echo "❌ This script must be run as root"
+    exit 1
+fi
+
+# Execute show-perms if requested
+if [ "$SHOW_PERMS" = true ]; then
+    show_current_permissions
+fi
+
+# Execute dry-run if requested
+if [ "$DRY_RUN" = true ]; then
+    dry_run
+fi
+
+echo "🔍 Verifying main directories..."
+check_main_directories
+
+echo "📁 Creating critical directories..."
+# Create critical directories based on version
+if [ "$MOODLE_VERSION" = "4" ]; then
+    create_moodle4_directories
+else
+    create_moodle5_directories
+fi
+
+echo "👤 Setting ownership..."
+chown -R ${WWW_USER}:${WWW_GROUP} "$MOODLE_DIR"
+chown -R ${WWW_USER}:${WWW_GROUP} "$MOODLEDATA_DIR"
+
+echo "📁 Setting base Moodle permissions..."
+find "$MOODLE_DIR" -type d -exec chmod 755 {} \;
+find "$MOODLE_DIR" -type f -exec chmod 644 {} \;
+
+# Check if config.php exists before modifying it
+if [ -f "$MOODLE_DIR/config.php" ]; then
+    echo "🔒 Protecting config.php..."
+    chmod 640 "$MOODLE_DIR/config.php"
+else
+    echo "⚠️  Warning: config.php not found in $MOODLE_DIR"
+fi
+
+echo "💾 Setting moodledata permissions..."
+find "$MOODLEDATA_DIR" -type d -exec chmod 770 {} \;
+find "$MOODLEDATA_DIR" -type f -exec chmod 660 {} \;
+
+# CLI scripts (common to both versions)
+if [ -d "$MOODLE_DIR/admin/cli" ]; then
+    find "$MOODLE_DIR/admin/cli" -name "*.php" -exec chmod 755 {} \;
+    echo "✅ CLI scripts set as executable"
+fi
+
+# Setting version-specific permissions
+if [ "$MOODLE_VERSION" = "4" ]; then
+    set_moodle4_permissions
+else
+    set_moodle5_permissions
+fi
+
+# Verify critical directory permissions
+echo "🔍 Verifying critical directory permissions..."
+for dir in "$MOODLEDATA_DIR" "$MOODLE_DIR"; do
+    if [ -d "$dir" ]; then
+        perms=$(stat -c "%a %U:%G" "$dir")
+        echo "   📁 $dir: $perms"
+    fi
+done
+
+# Verify specific directory permissions
+echo "🔍 Verifying specific Moodle ${MOODLE_VERSION} directory permissions..."
+if [ "$MOODLE_VERSION" = "4" ]; then
+    specific_dirs=("cache" "temp" "sessions" "lang" "h5p" "backup" "restore" "trashdir" "filedir" "repository" "log")
+else
+    specific_dirs=("cache" "temp" "lock" "tasks" "localcache" "sessions" "lang" "h5p" "backup" "restore" "trash")
+fi
+
+for dir in "${specific_dirs[@]}"; do
+    if [ -d "$MOODLEDATA_DIR/$dir" ]; then
+        perms=$(stat -c "%a %U:%G" "$MOODLEDATA_DIR/$dir")
+        echo "   📁 $MOODLEDATA_DIR/$dir: $perms"
+    fi
+done
+
+echo ""
+echo "✅ Moodle ${MOODLE_VERSION}.x permissions set correctly!"
+echo ""
+echo "📋 Configuration summary:"
+echo "   - Script version: ${SCRIPT_RELEASE} (${SCRIPT_CODENAME})"
+echo "   - Moodle version: ${MOODLE_VERSION}.x"
+echo "   - Moodle dir: $MOODLE_DIR (755/644)"
+echo "   - Moodledata: $MOODLEDATA_DIR (770/660)" 
+echo "   - Owner: $WWW_USER:$WWW_GROUP"
+echo "   - config.php: 640 (if present)"
+echo "   - CLI scripts: 755"
+echo ""
+
+# Version-specific notes
+if [ "$MOODLE_VERSION" = "4" ]; then
+    echo "⚠️  Important notes for Moodle 4:"
+    echo "   - PHP 7.4/8.0 required (8.0+ recommended)"
+    echo "   - MySQL 5.7+ or PostgreSQL 9.5+ or MariaDB 10.4+"
+    echo "   - Specific directories: trashdir/, filedir/, repository/"
+else
+    echo "⚠️  Important notes for Moodle 5:"
+    echo "   - PHP 8.1+ required"
+    echo "   - MySQL 8.0+ or PostgreSQL 13+ or MariaDB 10.6+ recommended"
+    echo "   - Specific directories: trash/, localcache/, lock/, tasks/"
+fi
+
+echo "   - Check logs in $MOODLEDATA_DIR for errors"
+echo ""
+echo "================================================================================"
+echo "Moodle Permissions Manager v${SCRIPT_RELEASE} - Operation completed"
+echo "Moodle ${MOODLE_VERSION}.x - Configuration applied successfully"
+echo "================================================================================"

--- a/conf.d/main
+++ b/conf.d/main
@@ -1,8 +1,9 @@
 #!/bin/bash -ex
 
+MOODLE_BRANCH="MOODLE_501_STABLE"
+
 WEBROOT=/var/www/moodle
 DATAROOT=/var/www/moodledata
-MOOSHROOT=/var/www/moosh
 
 DB_NAME=moodle
 DB_USER=moodle
@@ -34,26 +35,13 @@ a2enmod headers
 sed -Ei "/max_input_vars/ s|^;?(max_input_vars =).*|\1 5000|" /etc/php/8.2/apache2/php.ini
 sed -Ei "/max_input_vars/ s|^;?(max_input_vars =).*|\1 5000|" /etc/php/8.2/cli/php.ini
 
-cd $(dirname $MOOSHROOT)
-git clone https://github.com/tmuras/moosh.git
-cd $MOOSHROOT
-chown -R www-data:www-data $MOOSHROOT
-if [[ -n "$GITHUB_USER_TOKEN" ]]; then
-    turnkey-composer config github-oauth.github.com $GITHUB_USER_TOKEN
-else
-    echo "WARNING: GITHUB_USER_TOKEN not set, build may fail" >&2
-fi
-turnkey-composer install
-ln -s $MOOSHROOT/moosh.php /usr/local/bin/moosh
-
-# download latest moodle with moosh, then unpack
-cd $(dirname $WEBROOT)
-moosh download-moodle
-tar -C $(dirname $WEBROOT) -zxf moodle-*.tgz
-rm -f moodle-*.tgz
+# download latest moodle with git
+git clone git://git.moodle.org/moodle.git $WEBROOT
+cd $WEBROOT
+git branch --track $MOODLE_BRANCH origin/$MOODLE_BRANCH
+git checkout $MOODLE_BRANCH
 chown -R root:root $WEBROOT
 
-cd $WEBROOT
 php admin/cli/install.php \
     --chmod=750 \
     --lang=en \

--- a/conf.d/main
+++ b/conf.d/main
@@ -63,7 +63,6 @@ php admin/cli/install.php \
     --agree-license
 
 chown -R www-data:www-data $DATAROOT
-chown -R www-data:www-data /var/www/moodle/theme
 chown root:www-data $WEBROOT/config.php
 
 ## tweak config

--- a/conf.d/main
+++ b/conf.d/main
@@ -1,9 +1,8 @@
 #!/bin/bash -ex
 
-MOODLE_BRANCH="MOODLE_501_STABLE"
-
 WEBROOT=/var/www/moodle
 DATAROOT=/var/www/moodledata
+MOOSHROOT=/var/www/moosh
 
 DB_NAME=moodle
 DB_USER=moodle
@@ -35,13 +34,26 @@ a2enmod headers
 sed -Ei "/max_input_vars/ s|^;?(max_input_vars =).*|\1 5000|" /etc/php/8.2/apache2/php.ini
 sed -Ei "/max_input_vars/ s|^;?(max_input_vars =).*|\1 5000|" /etc/php/8.2/cli/php.ini
 
-# download latest moodle with git
-git clone git://git.moodle.org/moodle.git $WEBROOT
-cd $WEBROOT
-git branch --track $MOODLE_BRANCH origin/$MOODLE_BRANCH
-git checkout $MOODLE_BRANCH
+cd $(dirname $MOOSHROOT)
+git clone https://github.com/tmuras/moosh.git
+cd $MOOSHROOT
+chown -R www-data:www-data $MOOSHROOT
+if [[ -n "$GITHUB_USER_TOKEN" ]]; then
+    turnkey-composer config github-oauth.github.com $GITHUB_USER_TOKEN
+else
+    echo "WARNING: GITHUB_USER_TOKEN not set, build may fail" >&2
+fi
+turnkey-composer install
+ln -s $MOOSHROOT/moosh.php /usr/local/bin/moosh
+
+# download latest moodle with moosh, then unpack
+cd $(dirname $WEBROOT)
+moosh download-moodle
+tar -C $(dirname $WEBROOT) -zxf moodle-*.tgz
+rm -f moodle-*.tgz
 chown -R root:root $WEBROOT
 
+cd $WEBROOT
 php admin/cli/install.php \
     --chmod=750 \
     --lang=en \

--- a/conf.d/main
+++ b/conf.d/main
@@ -123,7 +123,7 @@ SCRIPT_AUTHOR="Daniele Lolli (UncleDan)"
 SCRIPT_LICENSE="GPL-3.0"
 
 # Default Moodle version (independent from script release)
-DEFAULT_MOODLE_VERSION="4"
+## DEFAULT_MOODLE_VERSION="4" ## Keep the version you found!!
 
 set -e  # Exit immediately on error
 

--- a/conf.d/main
+++ b/conf.d/main
@@ -74,7 +74,6 @@ php admin/cli/install.php \
     --agree-license
 
 chown -R www-data:www-data $DATAROOT
-chown -R www-data:www-data /var/www/moodle/theme
 chown root:www-data $WEBROOT/config.php
 
 ## tweak config

--- a/overlay/etc/apache2/sites-available/moodle.conf
+++ b/overlay/etc/apache2/sites-available/moodle.conf
@@ -9,7 +9,7 @@ ErrorDocument 403 /error/index.php?code=404
 <VirtualHost *:80>
     UseCanonicalName Off
     ServerAdmin  webmaster@localhost
-    DocumentRoot /var/www/moodle/
+    DocumentRoot /var/www/moodle/public/
     RewriteEngine On
     RewriteCond %{HTTP_HOST} !=localhost
     RewriteCond %{REMOTE_ADDR} !=127.0.0.1
@@ -19,7 +19,7 @@ ErrorDocument 403 /error/index.php?code=404
 <VirtualHost *:443>
     SSLEngine on
     ServerAdmin  webmaster@localhost
-    DocumentRoot /var/www/moodle/
+    DocumentRoot /var/www/moodle/public/
     RewriteEngine On
     RewriteRule "(\/vendor\/)" - [F]
     RewriteRule "(\/node_modules\/)" - [F]


### PR DESCRIPTION
turnkey-moodle5-18.1 (1) turnkey; urgency=low

  * Install latest upstream version of Moodle 5.x: 5.1.0+ (as of today,
    download via git branch MOODLE_501_STABLE).

  * Set correct permissions and creating (eventually) missing folders.

  * Change pointing to /public.